### PR TITLE
Use AppleScript for notifications in MacOS instead of DBus

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ guessit = "*"
 pywin32 = {version = "*", sys_platform = "== 'win32'"}
 win10toast = {version = "*", sys_platform = "== 'win32'"}
 notify2 = {version = "*", sys_platform = "!= 'win32'"}
-dbus-python = {version = "*", sys_platform = "!= 'win32'"}
+dbus-python = {version = "*", sys_platform = "== 'linux'"}
 toml = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d85fcdcca0bfa85615899e4d0cb813a27a5301d04ec04246cb913a2a72b0e854"
+            "sha256": "9b7b722069294eb506cb1b78811e6afead4a66260fff53490de8b04d11dc303a"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -22,10 +22,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
         },
         "chardet": {
             "hashes": [
@@ -36,18 +36,18 @@
         },
         "dbus-python": {
             "hashes": [
-                "sha256:abf12bbb765e300bf8e2a1b2f32f85949eab06998dbda127952c31cb63957b6f"
+                "sha256:cdd4de2c4f5e58f287b12013ed7b41dee81d503c8d0d2397c5bd2fb01badf260"
             ],
             "index": "pypi",
-            "markers": "sys_platform != 'win32'",
-            "version": "==1.2.8"
+            "markers": "sys_platform == 'linux'",
+            "version": "==1.2.12"
         },
         "guessit": {
             "hashes": [
-                "sha256:37803ec0d7f20f2e1425dfe3bb978dc3b9c65872aa3760c664b31a9115232ec1"
+                "sha256:2dcd3f2acaf6c1a864f903f084ddd6a6b753f3107ae864355d7c8c1e9cb205b2"
             ],
             "index": "pypi",
-            "version": "==3.0.4"
+            "version": "==3.1.0"
         },
         "idna": {
             "hashes": [
@@ -81,24 +81,28 @@
         },
         "pywin32": {
             "hashes": [
-                "sha256:22e218832a54ed206452c8f3ca9eff07ef327f8e597569a4c2828be5eaa09a77",
-                "sha256:32b37abafbfeddb0fe718008d6aada5a71efa2874f068bee1f9e703983dcc49a",
-                "sha256:35451edb44162d2f603b5b18bd427bc88fcbc74849eaa7a7e7cfe0f507e5c0c8",
-                "sha256:4eda2e1e50faa706ff8226195b84fbcbd542b08c842a9b15e303589f85bfb41c",
-                "sha256:5f265d72588806e134c8e1ede8561739071626ea4cc25c12d526aa7b82416ae5",
-                "sha256:6852ceac5fdd7a146b570655c37d9eacd520ed1eaeec051ff41c6fc94243d8bf",
-                "sha256:6dbc4219fe45ece6a0cc6baafe0105604fdee551b5e876dc475d3955b77190ec",
-                "sha256:9bd07746ce7f2198021a9fa187fa80df7b221ec5e4c234ab6f00ea355a3baf99"
+                "sha256:0443e9bb196e72480f50cbddc2cf98fbb858a77d02e281ba79489ea3287b36e9",
+                "sha256:09bbe7cdb29eb40ab2e83f7a232eeeedde864be7a0622b70a90f456aad07a234",
+                "sha256:0d8e0f47808798d320c983574c36c49db642678902933a210edd40157d206fd0",
+                "sha256:0db7c9f4b93528afd080d35912a60be2f86a1d6c49c0a9cf9cedd106eed81ea3",
+                "sha256:749e590875051661ecefbd9dfa957a485016de0f25e43f5e70f888ef1e29587b",
+                "sha256:779d3e9d4b934f2445d2920c3941416d99af72eb7f7fd57a63576cc8aa540ad6",
+                "sha256:7c89d2c11a31c7aaa16dc4d25054d7e0e99d6f6b24193cf62c83850484658c87",
+                "sha256:81f7732b662c46274d7d8c411c905d53e71999cba95457a0686467c3ebc745ca",
+                "sha256:9db1fb8830bfa99c5bfd335d4482c14db5c6f5028db3b006787ef4200206242b",
+                "sha256:bd8d04835db28646d9e07fd0ab7c7b18bd90e89dfdc559e60389179495ef30da",
+                "sha256:fc6822a68afd79e97b015985dd455767c72009b81bcd18957068626c43f11e75",
+                "sha256:fe6cfc2045931866417740b575231c7e12d69d481643be1493487ad53b089959"
             ],
             "index": "pypi",
             "markers": "sys_platform == 'win32'",
-            "version": "==224"
+            "version": "==225"
         },
         "rebulk": {
             "hashes": [
-                "sha256:1d49e4f7ef6fb874e60efccacbbe661092fabdb7770cdf7f7de4516d50535998"
+                "sha256:1b0d526859ef3e8647f37c606d7ae7c32259e370b3f1519e4219a3ba72740aec"
             ],
-            "version": "==1.0.0"
+            "version": "==2.0.0"
         },
         "requests": {
             "hashes": [
@@ -125,10 +129,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
-                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+                "sha256:3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398",
+                "sha256:9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"
             ],
-            "version": "==1.25.3"
+            "version": "==1.25.6"
         },
         "win10toast": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ Other player specific parameters| See sample config for the required attributes.
 		3. Edit the `scripts/trakt_scrobbler.plist` file to add the correct folder path of the project.
 		4. `cp scripts/trakt_scrobbler.plist ~/Library/LaunchAgents/`
 		5. `launchctl load ~/Library/LaunchAgents/trakt_scrobbler.plist`
-		6. Type `pipenv run python main.py` to start the program. You will be prompted to authorize the program to access the Trakt.tv API. Follow the steps on screen to finish the process. In the future, the script will run on computer boot, without any need for human intervention.
+		6. `mkdir ~/Library/Preferences/trakt-scrobbler/ && cp config.toml ~/Library/Preferences/trakt-scrobbler/`
+		7. Type `pipenv run python trakt_scrobbler/main.py` to start the program. You will be prompted to authorize the program to access the Trakt.tv API. Follow the steps on screen to finish the process. In the future, the script will run on computer boot, without any need for human intervention.
 
-5. To enable notification support on Linux/MacOS, the dbus libraries need to be installed (Reboot after installation).
+5. To enable notification support on Linux, the dbus libraries need to be installed (Reboot after installation).
+	- Arch/Manjaro: `pacman -S python-dbus`
 	- Ubuntu: `apt install python3-dbus`
-	- MacOS: `brew install dbus`
 
 ## Updating
 Substitute the values according to your OS in the following steps

--- a/trakt_scrobbler/log_config.py
+++ b/trakt_scrobbler/log_config.py
@@ -25,10 +25,7 @@ class ModuleFilter(logging.Filter):
     min_levels = {}
 
     def filter(self, record: logging.LogRecord):
-        if record.module in self.min_levels.keys() and \
-           record.levelno < self.min_levels[record.module]:
-            return False
-        return True
+        return record.levelno >= self.min_levels.get(record.module, -1)
 
 
 LOGGING_CONF = {
@@ -36,7 +33,7 @@ LOGGING_CONF = {
     'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
-            'format': '{asctime} - {levelname} - {threadName} - {module} - {message}',  # Ignore PycodestyleBear (E501)
+            'format': '{asctime} - {levelname} - {threadName} - {module} - {message}',
             'style': '{'
         },
         'brief': {

--- a/trakt_scrobbler/notifier.py
+++ b/trakt_scrobbler/notifier.py
@@ -3,21 +3,27 @@ from utils import config
 
 APP_NAME = 'Trakt Scrobbler'
 
-if sys.platform != 'win32':
-    import notify2
-    notify2.init(APP_NAME)
-else:
-    from win10toast import ToastNotifier
-    toaster = ToastNotifier()
+if config['general']['enable_notifs']:
+    if sys.platform == 'win32':
+        from win10toast import ToastNotifier
+        toaster = ToastNotifier()
+    elif sys.platform == 'darwin':
+        import subprocess as sp
+    else:
+        import notify2
+        notify2.init(APP_NAME)
 
 
 def notify(body, title=APP_NAME, timeout=5):
     if not config['general']['enable_notifs']:
         print(title, body)
         return
-    if sys.platform != 'win32':
+    if sys.platform == 'win32':
+        toaster.show_toast(title, body, duration=timeout, threaded=True)
+    elif sys.platform == 'darwin':
+        osa_cmd = f'display notification "{body}" with title "{title}"'
+        sp.run(["osascript", "-e", osa_cmd])
+    else:
         notif = notify2.Notification(title, body)
         notif.timeout = timeout * 1000
         notif.show()
-    else:
-        toaster.show_toast(title, body, duration=timeout, threaded=True)


### PR DESCRIPTION
As DBus was causing a lot of issues in MacOS, this code uses the native AppleScript interface to send notifications.

Closes #26 #22 