### PR TITLE
Replaceable notifications using DBus

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -93,33 +93,24 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "jeepney"
+version = "0.6.0"
+description = "Low-level, pure Python DBus protocol wrapper."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+marker = "sys_platform == \"linux\""
+
+[package.extras]
+test = ["pytest", "pytest-trio", "pytest-asyncio", "testpath", "trio"]
+
+[[package]]
 name = "pastel"
 version = "0.2.1"
 description = "Bring colors to your terminal."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
-name = "pycairo"
-version = "1.20.0"
-description = "Python interface for cairo"
-category = "main"
-optional = true
-python-versions = ">=3.6, <4"
-marker = "sys_platform == \"linux\""
-
-[[package]]
-name = "pygobject"
-version = "3.38.0"
-description = "Python bindings for GObject Introspection"
-category = "main"
-optional = true
-python-versions = ">=3.5, <4"
-marker = "sys_platform == \"linux\""
-
-[package.dependencies]
-pycairo = ">=1.11.1"
 
 [[package]]
 name = "pylev"
@@ -244,12 +235,11 @@ setuptools = "*"
 
 [extras]
 socks = ["pysocks"]
-linux_gobject = ["pygobject"]
 
 [metadata]
 lock-version = "1.0"
 python-versions = "^3.7"
-content-hash = "b9b3c562357b9da3064761035ae87666e8769e56d17ab694e90e01e9357e417c"
+content-hash = "6ca518b9e85e9e68be81991aeac99d3510b2d36b18f8e24c61aadd30486a467c"
 
 [metadata.files]
 appdirs = [
@@ -287,23 +277,13 @@ idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
+jeepney = [
+    {file = "jeepney-0.6.0-py3-none-any.whl", hash = "sha256:aec56c0eb1691a841795111e184e13cad504f7703b9a64f63020816afa79a8ae"},
+    {file = "jeepney-0.6.0.tar.gz", hash = "sha256:7d59b6622675ca9e993a6bd38de845051d315f8b0c72cca3aef733a20b648657"},
+]
 pastel = [
     {file = "pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364"},
     {file = "pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d"},
-]
-pycairo = [
-    {file = "pycairo-1.20.0-cp36-cp36m-win32.whl", hash = "sha256:e5a3433690c473e073a9917dc8f1fc7dc8b9af7b201bf372894b8ad70d960c6d"},
-    {file = "pycairo-1.20.0-cp36-cp36m-win_amd64.whl", hash = "sha256:a942614923b88ae75c794506d5c426fba9c46a055d3fdd3b8db7046b75c079cc"},
-    {file = "pycairo-1.20.0-cp37-cp37m-win32.whl", hash = "sha256:8cfa9578b745fb9cf2915ec580c2c50ebc2da00eac2cf4c4b54b63aa19da4b77"},
-    {file = "pycairo-1.20.0-cp37-cp37m-win_amd64.whl", hash = "sha256:273a33c56aba724ec42fe1d8f94c86c2e2660c1277470be9b04e5113d7c5b72d"},
-    {file = "pycairo-1.20.0-cp38-cp38-win32.whl", hash = "sha256:2088100a099c09c5e90bf247409ce6c98f51766b53bd13f96d6aac7addaa3e66"},
-    {file = "pycairo-1.20.0-cp38-cp38-win_amd64.whl", hash = "sha256:ceb1edcbeb48dabd5fbbdff2e4b429aa88ddc493d6ebafe78d94b050ac0749e2"},
-    {file = "pycairo-1.20.0-cp39-cp39-win32.whl", hash = "sha256:57a768f4edc8a9890d98070dd473a812ac3d046cef4bc1c817d68024dab9a9b4"},
-    {file = "pycairo-1.20.0-cp39-cp39-win_amd64.whl", hash = "sha256:57166119e424d71eccdba6b318bd731bdabd17188e2ba10d4f315f7bf16ace3f"},
-    {file = "pycairo-1.20.0.tar.gz", hash = "sha256:5695a10cb7f9ae0d01f665b56602a845b0a8cb17e2123bfece10c2e58552468c"},
-]
-pygobject = [
-    {file = "PyGObject-3.38.0.tar.gz", hash = "sha256:051b950f509f2e9f125add96c1493bde987c527f7a0c15a1f7b69d6d1c3cd8e6"},
 ]
 pylev = [
     {file = "pylev-1.3.0-py2.py3-none-any.whl", hash = "sha256:1d29a87beb45ebe1e821e7a3b10da2b6b2f4c79b43f482c2df1a1f748a6e114e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ win10toast = {version = "^0.9", platform = "win32"}
 cleo = "^0.7.6"
 confuse = "^1.3.0"
 pysocks = {version = "^1.7.1", optional = true}
-pydbus = { version = "^0.6", platform = "linux"}
+jeepney = { version = "^0.6", platform = "linux"}
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,13 +24,12 @@ win10toast = {version = "^0.9", platform = "win32"}
 cleo = "^0.7.6"
 confuse = "^1.3.0"
 pysocks = {version = "^1.7.1", optional = true}
-pygobject = { version = "^3.34", platform = "linux",  optional = true}
+pydbus = { version = "^0.6", platform = "linux"}
 
 [tool.poetry.dev-dependencies]
 
 [tool.poetry.extras]
 socks = ["pysocks"]
-linux_gobject = ["pygobject"]
 
 [tool.poetry.scripts]
 trakts = "trakt_scrobbler.console:main"

--- a/trakt_scrobbler/notifier.py
+++ b/trakt_scrobbler/notifier.py
@@ -27,6 +27,7 @@ if enable_notifs:
 
 
 def dbus_notify(title, body, timeout):
+    global notif_id
     connection = open_dbus_connection(bus='SESSION')
     msg = new_method_call(notifier, 'Notify', 'susssasa{sv}i',
                           (
@@ -37,16 +38,14 @@ def dbus_notify(title, body, timeout):
                               body,
                               [], {},
                               timeout,
-                          )
-                          )
+                          ))
     reply = connection.send_and_get_reply(msg)
     connection.close()
-    return reply.body[0]
+    notif_id = reply.body[0]
 
 
 def notify(body, title=APP_NAME, timeout=5, stdout=False):
     global enable_notifs
-    global notif_id
 
     if stdout or not enable_notifs:
         print(body)
@@ -58,7 +57,7 @@ def notify(body, title=APP_NAME, timeout=5, stdout=False):
         osa_cmd = f'display notification "{body}" with title "{title}"'
         sp.run(["osascript", "-e", osa_cmd], check=False)
     elif notifier is not None:
-        notif_id = dbus_notify(title, body, timeout * 1000)
+        dbus_notify(title, body, timeout * 1000)
     else:
         try:
             sp.run([

--- a/trakt_scrobbler/notifier.py
+++ b/trakt_scrobbler/notifier.py
@@ -3,11 +3,11 @@ import confuse
 from trakt_scrobbler import config, logger
 
 APP_NAME = 'Trakt Scrobbler'
-enable_notifs = config['general']['enable_notifs'].get(
+ENABLE_NOTIFS = config['general']['enable_notifs'].get(
     confuse.Choice([True, False], default=True)
 )
 
-if enable_notifs:
+if ENABLE_NOTIFS:
     if sys.platform == 'win32':
         from win10toast import ToastNotifier
 
@@ -23,23 +23,21 @@ if enable_notifs:
 
 
 def notify(body, title=APP_NAME, timeout=5, stdout=False):
-    global enable_notifs
+    _globals = globals()
 
-    if stdout or not enable_notifs:
+    if stdout or not _globals['ENABLE_NOTIFS']:
         print(body)
-    if not enable_notifs:
+    if not _globals['ENABLE_NOTIFS']:
         return
     if sys.platform == 'win32':
         toaster.show_toast(title, body, duration=timeout, threaded=True)
     elif sys.platform == 'darwin':
         osa_cmd = f'display notification "{body}" with title "{title}"'
         sp.run(["osascript", "-e", osa_cmd], check=False)
-    elif 'SessionBus' in globals() and 'NOTIFIER' in globals():
-        global NOTIFIER
-        global NOTIF_ID
-        NOTIF_ID = NOTIFIER.Notify(
+    elif 'SessionBus' in _globals and 'NOTIFIER' in _globals:
+        _globals['NOTIF_ID'] = NOTIFIER.Notify(
             APP_NAME,
-            NOTIF_ID,
+            _globals['NOTIF_ID'],
             'dialog-information',
             title,
             body,
@@ -59,4 +57,5 @@ def notify(body, title=APP_NAME, timeout=5, stdout=False):
             ], check=False)
         except FileNotFoundError:
             logger.exception("Unable to send notification")
-            enable_notifs = False  # disable all future notifications until app restart
+            # disable all future notifications until app restart
+            _globals['ENABLE_NOTIFS'] = False


### PR DESCRIPTION
Replaceable notifications using dbus

- Use `SessionBus` from pydbus to send replaceable notification using
  `org.freedesktop.Notifications.Notify`
- Remove pygobject dependency.
