### PR TITLE
vlc: Add fallback for http-password

### DIFF
--- a/trakt_scrobbler/player_monitors/vlc.py
+++ b/trakt_scrobbler/player_monitors/vlc.py
@@ -61,7 +61,7 @@ class VLCMon(WebInterfaceMon):
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), vlcrc_path)
         return {
             "port": lambda: vlcrc.get("core", "http-port", fallback=8080),
-            "password": lambda: vlcrc.get("lua", "http-password"),
+            "password": lambda: vlcrc.get("lua", "http-password", fallback=""),
         }
 
     def update_status(self):


### PR DESCRIPTION
allow player monitor to support older versions of VLC.

This change prevents an exception from occurring on older versions of VLC before the 'http-password' config element was introduced, enabling the monitor to work correctly.