### PR TITLE
trakt_if: Add search retry without 'year'

### DIFF
--- a/trakt_scrobbler/trakt_interface.py
+++ b/trakt_scrobbler/trakt_interface.py
@@ -40,8 +40,11 @@ def get_trakt_id(title, item_type, year=None):
 
     logger.debug(f'Searching trakt: Title: "{title}"{year and f", Year: {year}" or ""}')
     results = search(title, [required_type], year)
-    if results == []: # no match
-        results = search(title, [required_type]) # possible mismatch in metadata, retry without 'year'
+    if (results == [] and year is not None): # no match, possibly a mismatch in year metadata
+        msg = f'Trakt search yielded no results for the {required_type}, {title}, Year: {year}. Retrying search without filtering by year'
+        logger.warning(msg)
+        notify(msg, category="trakt")
+        results = search(title, [required_type]) # retry without 'year'
 
     if results is None:  # Connection error
         return 0  # Dont store in cache

--- a/trakt_scrobbler/trakt_interface.py
+++ b/trakt_scrobbler/trakt_interface.py
@@ -40,6 +40,9 @@ def get_trakt_id(title, item_type, year=None):
 
     logger.debug(f'Searching trakt: Title: "{title}"{year and f", Year: {year}" or ""}')
     results = search(title, [required_type], year)
+    if results == []: # no match
+        results = search(title, [required_type]) # possible mismatch in metadata, retry without 'year'
+
     if results is None:  # Connection error
         return 0  # Dont store in cache
     elif results == [] or results[0]['score'] < 5:  # Weak or no match

--- a/trakt_scrobbler/trakt_interface.py
+++ b/trakt_scrobbler/trakt_interface.py
@@ -40,11 +40,13 @@ def get_trakt_id(title, item_type, year=None):
 
     logger.debug(f'Searching trakt: Title: "{title}"{year and f", Year: {year}" or ""}')
     results = search(title, [required_type], year)
-    if (results == [] and year is not None): # no match, possibly a mismatch in year metadata
-        msg = f'Trakt search yielded no results for the {required_type}, {title}, Year: {year}. Retrying search without filtering by year'
+    if results == [] and year is not None:
+        # no match, possibly a mismatch in year metadata
+        msg = (f'Trakt search yielded no results for the {required_type}, {title}, '
+               f'Year: {year}. Retrying search without filtering by year.')
         logger.warning(msg)
         notify(msg, category="trakt")
-        results = search(title, [required_type]) # retry without 'year'
+        results = search(title, [required_type])  # retry without 'year'
 
     if results is None:  # Connection error
         return 0  # Dont store in cache


### PR DESCRIPTION
Trakt 'year' metadata will infrequently disagree with other sources. In case search() returns no matches, retry without filtering by year.

Closes #129