### PR TITLE
cli: autostart: Fix start/stop command errors on macOS

### DIFF
--- a/trakt_scrobbler/commands/autostart.py
+++ b/trakt_scrobbler/commands/autostart.py
@@ -48,10 +48,6 @@ class AutostartEnableCommand(Command):
                 </array>
                 <key>RunAtLoad</key>
                 <true />
-                <key>LaunchOnlyOnce</key>
-                <true />
-                <key>KeepAlive</key>
-                <true />
             </dict>
             </plist>
             """


### PR DESCRIPTION
Fixes #83 , tested on macOS Catalina version 10.15.7