### PR TITLE
poetry/sdist: Include tests and completions in tarball

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,12 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 
+packages = [
+	{include = "trakt_scrobbler"},
+	{include = "tests", format = "sdist"},
+	{include = "completions/**/*.*?sh", format = "sdist"}
+]
+
 [tool.poetry.dependencies]
 python = "^3.7"
 requests = "^2.25.1"


### PR DESCRIPTION
I just noticed that, tests and completions aren't included in the source tarball available in pypi, so I had to do this.
