### PR TITLE
poetry: Use `include[]` instead of `package[]`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,9 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     "Operating System :: OS Independent",
 ]
-
-packages = [
-	{include = "trakt_scrobbler"},
-	{include = "tests", format = "sdist"},
-	{include = "completions/**/*.*?sh", format = "sdist"}
+include = [
+	{path = "tests", format = "sdist"},
+	{path = "completions/**/*.*?sh", format = "sdist"}
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Including tests with `package[]` made setup.py install a package named
`test` which was not intended. This commit fixes this

See-also: d2419b1171a451 (poetry/sdist: Include tests and completions in tarball (#178))
Signed-off-by: Mubashshir <ahmubashshir@gmail.com>
