### PR TITLE
Use UTF-8 as default decode for mpv.conf

### DIFF
--- a/trakt_scrobbler/player_monitors/mpv.py
+++ b/trakt_scrobbler/player_monitors/mpv.py
@@ -68,7 +68,7 @@ class MPVMon(Monitor):
             allow_no_value=True, strict=False, inline_comment_prefixes="#"
         )
         mpv_conf.optionxform = lambda option: option
-        mpv_conf.read_string("[root]\n" + conf_path.read_text())
+        mpv_conf.read_string("[root]\n" + conf_path.read_text(encoding="utf-8"))
         return {
             "ipc_path": lambda: mpv_conf.get("root", "input-ipc-server")
         }

--- a/trakt_scrobbler/player_monitors/mpv_wrappers.py
+++ b/trakt_scrobbler/player_monitors/mpv_wrappers.py
@@ -31,7 +31,7 @@ class SMPlayerMPVMon(MPVMon):
             )
         mpv_conf = ConfigParser(allow_no_value=True, strict=False)
         mpv_conf.optionxform = lambda option: option
-        mpv_conf.read_string(conf_path.read_text())
+        mpv_conf.read_string(conf_path.read_text(encoding="utf-8"))
 
         def read_ipc():
             opts = mpv_conf.get("advanced", "mplayer_additional_options")


### PR DESCRIPTION
Fixed https://github.com/iamkroot/trakt-scrobbler/issues/183