### PR TITLE
Handle `int` declared as `str` for `match.episode` on remaps

### DIFF
--- a/trakt_scrobbler/mediainfo_remap.py
+++ b/trakt_scrobbler/mediainfo_remap.py
@@ -80,8 +80,8 @@ class NumOrRange:
                 raise ValueError("Invalid range")
             start = int(m.group("start"))
             try:
-                end = int(m["end"])
-            except (KeyError, TypeError):
+                end = int(m["end"]) if m["end"] != None else start
+            except KeyError:
                 end = start
             assert start <= end, f"Got start={start} > end={end}"
             return cls(start, end)

--- a/trakt_scrobbler/mediainfo_remap.py
+++ b/trakt_scrobbler/mediainfo_remap.py
@@ -81,7 +81,7 @@ class NumOrRange:
             start = int(m.group("start"))
             try:
                 end = int(m["end"])
-            except KeyError:
+            except (KeyError, TypeError):
                 end = start
             assert start <= end, f"Got start={start} > end={end}"
             return cls(start, end)

--- a/trakt_scrobbler/player_monitors/plex.py
+++ b/trakt_scrobbler/player_monitors/plex.py
@@ -102,7 +102,7 @@ class PlexMon(WebInterfaceMon):
             return data["Metadata"][0]
 
         for metadata in data["Metadata"]:
-            if metadata["User"]["title"] == self.config["scrobble_user"]:
+            if metadata["User"].get("title") == self.config["scrobble_user"]:
                 return metadata
 
     def _update_status(self):


### PR DESCRIPTION
### What Happens
trakt-scrobbler silently crashes with the following entry to `remap_rules.toml`:
```toml
[[rules]]
match.title = "Doctor Who"
match.year = 2005
match.episode = "168"
match.season = 0
id.trakt_slug = "doctor-who-2024"
type = "episode"
episode_delta = -164
```

### What Should Happen
Parser should gracefully handle a single episode declared as a string.

### What changed
Added `TypeError` to the caught exceptions as groups contained in a part of the expression that don't match (`m["end"]`) return a `NoneType` ([docs](https://docs.python.org/3/library/re.html#re.Match.group)) which causes the `int()` operation fail instead of the mapping.