### PR TITLE
Use getters instead of relying on Exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,10 @@ dist/
 trakt_scrobbler.egg-info/
 wiki/
 aur/
+
+# Python venv #
+###############
+Scripts/
+Lib/
+Include/
+pyvenv.cfg


### PR DESCRIPTION
Would crash if the Trakt cache file existed but didn't have one of the keys.

Fixes #311